### PR TITLE
Allow using block syntax in logger 

### DIFF
--- a/lib/logasm.rb
+++ b/lib/logasm.rb
@@ -25,24 +25,24 @@ class Logasm
     @preprocessors = preprocessors
   end
 
-  def debug(*args)
-    log :debug, *args
+  def debug(*args, &block)
+    log :debug, *args, &block
   end
 
-  def info(*args)
-    log :info, *args
+  def info(*args, &block)
+    log :info, *args, &block
   end
 
-  def warn(*args)
-    log :warn, *args
+  def warn(*args, &block)
+    log :warn, *args, &block
   end
 
-  def error(*args)
-    log :error, *args
+  def error(*args, &block)
+    log :error, *args, &block
   end
 
-  def fatal(*args)
-    log :fatal, *args
+  def fatal(*args, &block)
+    log :fatal, *args, &block
   end
 
   LOG_LEVEL_QUERY_METHODS.each do |method|
@@ -53,8 +53,8 @@ class Logasm
 
   private
 
-  def log(level, *args)
-    data = parse_log_data(*args)
+  def log(level, *args, &block)
+    data = parse_log_data(*args, &block)
     processed_data = preprocess(data)
 
     @adapters.each do |adapter|
@@ -68,9 +68,9 @@ class Logasm
     end
   end
 
-  def parse_log_data(message, metadata = {})
+  def parse_log_data(message = nil, metadata = {}, &block)
     return message if message.is_a?(Hash)
 
-    (metadata || {}).merge(message: message)
+    (metadata || {}).merge(message: block ? block.call : message)
   end
 end

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "logasm"
-  gem.version       = '0.4.0'
+  gem.version       = '0.4.1'
   gem.authors       = ["Salemove"]
   gem.email         = ["support@salemove.com"]
   gem.description   = %q{It's logasmic}

--- a/spec/logasm_spec.rb
+++ b/spec/logasm_spec.rb
@@ -98,6 +98,20 @@ describe Logasm do
 
       logasm.info 'test message', test: 'data'
     end
+
+    it 'parses block as a message' do
+      message = 'test message'
+      expect(adapter).to receive(:log).with(:info, message: message)
+
+      logasm.info { message }
+    end
+
+    it 'ignores progname on block syntax' do
+      message = 'test message'
+      expect(adapter).to receive(:log).with(:info, message: message)
+
+      logasm.info('progname') { message }
+    end
   end
 
   context 'log level queries' do


### PR DESCRIPTION
See http://ruby-doc.org/stdlib-2.1.0/libdoc/logger/rdoc/Logger.html#method-i-info for more information.