### PR TITLE
Allow whitelisting Hash objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Received request {"info":{"phone":"************"}}
 
 Masks all the fields except those whitelisted in the configuration using [JSON Pointer](https://tools.ietf.org/html/rfc6901).
 Only simple values(`string`, `number`, `boolean`) can be whitelisted.
-Whitelisting array elements can be done using wildcard symbol `~`.
+Whitelisting array and hash elements can be done using wildcard symbol `~`.
 
 #### Configuration
 

--- a/lib/logasm/preprocessors/whitelist.rb
+++ b/lib/logasm/preprocessors/whitelist.rb
@@ -85,8 +85,14 @@ class Logasm
       end
 
       def process_hash(parent_pointer, hash)
+        create_child_pointer =
+          if @wildcards["#{parent_pointer}/~"]
+            lambda { |_| "#{parent_pointer}/~" }
+          else
+            lambda { |key| "#{parent_pointer}/#{key}" }
+          end
         hash.inject({}) do |mem, (key, value)|
-          pointer = "#{parent_pointer}/#{key}"
+          pointer = create_child_pointer.call(key)
           processed_value = process_data(pointer, value)
           mem.merge(key => processed_value)
         end

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "logasm"
-  gem.version       = '0.5.2'
+  gem.version       = '0.6.0'
   gem.authors       = ["Salemove"]
   gem.email         = ["support@salemove.com"]
   gem.description   = %q{It's logasmic}

--- a/spec/preprocessors/whitelist_spec.rb
+++ b/spec/preprocessors/whitelist_spec.rb
@@ -74,6 +74,20 @@ describe Logasm::Preprocessors::Whitelist do
     end
   end
 
+  context 'with whitelisted hash' do
+    it 'includes all whitelisted hash elements' do
+      source = {foo: {bar: 'baz'}}
+      target = {foo: {bar: 'baz'}}
+      expect(process(['/foo/~'], source)).to eq(target)
+    end
+
+    it 'does not include nested elements' do
+      source = {foo: {bar: {baz: 'asd'}}}
+      target = {foo: {bar: {baz: '***'}}}
+      expect(process(['/foo/~'], source)).to eq(target)
+    end
+  end
+
   context 'with whitelisted array elements field with wildcard' do
     let(:data) {{
       array: [{field: 'data1', secret: 'secret1'}, {field: 'data2', secret: 'secret2'}]
@@ -183,5 +197,9 @@ describe Logasm::Preprocessors::Whitelist do
     it 'includes field' do
       expect(processed_data).to include('field_with_~1'=> 'secret')
     end
+  end
+
+  def process(pointers, data)
+    described_class.new(pointers: pointers).process(data)
   end
 end


### PR DESCRIPTION
E.g. If you have an object `{x: 'y', trace: {a: 'b', b: 'c'}}` then you might want to whitelist the whole `trace` object.