### PR TITLE
Use fixed mask value for excluded keys

### DIFF
--- a/lib/logasm/preprocessors/blacklist.rb
+++ b/lib/logasm/preprocessors/blacklist.rb
@@ -4,6 +4,7 @@ class Logasm
 
       DEFAULT_ACTION = 'exclude'
       MASK_SYMBOL = '*'
+      MASKED_VALUE = MASK_SYMBOL * 5
 
       class UnsupportedActionException < Exception
       end
@@ -48,19 +49,11 @@ class Logasm
       end
 
       def mask_field(data, key, val)
-        if val.is_a?(Hash) || val.is_a?(Array) || is_boolean?(val)
-          data.merge(key => MASK_SYMBOL)
-        else
-          data.merge(key => MASK_SYMBOL * val.to_s.length)
-        end
+        data.merge(key => MASKED_VALUE)
       end
 
       def exclude_field(data, *)
         data
-      end
-
-      def is_boolean?(val)
-        val.is_a?(TrueClass) || val.is_a?(FalseClass)
       end
     end
   end

--- a/lib/logasm/preprocessors/whitelist.rb
+++ b/lib/logasm/preprocessors/whitelist.rb
@@ -4,6 +4,7 @@ class Logasm
 
       DEFAULT_WHITELIST = %w(/id /message /correlation_id /queue)
       MASK_SYMBOL = '*'
+      MASKED_VALUE = MASK_SYMBOL * 5
       WILDCARD = '~'
 
       class InvalidPointerFormatException < Exception
@@ -110,20 +111,8 @@ class Logasm
         if @fields_to_include[parent_pointer]
           value
         else
-          mask value
+          MASKED_VALUE
         end
-      end
-
-      def mask(value)
-        if value && value.respond_to?(:to_s) && !is_boolean?(value)
-          MASK_SYMBOL * value.to_s.length
-        else
-          MASK_SYMBOL
-        end
-      end
-
-      def is_boolean?(value)
-        value.is_a?(TrueClass) || value.is_a?(FalseClass)
       end
     end
   end

--- a/spec/preprocessors/blacklist_spec.rb
+++ b/spec/preprocessors/blacklist_spec.rb
@@ -56,18 +56,18 @@ describe Logasm::Preprocessors::Blacklist do
     let(:action) { 'mask' }
 
     it 'masks nested field' do
-      expect(processed_data).to include_at_depth({field: '******'}, 1)
+      expect(processed_data).to include_at_depth({field: '*****'}, 1)
     end
 
     it 'masks nested in array field' do
-      expect(processed_data[:array]).to include({field: '******'})
+      expect(processed_data[:array]).to include({field: '*****'})
     end
 
     context 'when field is string' do
       let(:value) { 'secret' }
 
       it 'masks value with asterisks' do
-        expect(processed_data).to include(field: '******')
+        expect(processed_data).to include(field: '*****')
       end
     end
 
@@ -75,31 +75,31 @@ describe Logasm::Preprocessors::Blacklist do
       let(:value) { 42 }
 
       it 'masks number value' do
-        expect(processed_data).to include(field: '**')
+        expect(processed_data).to include(field: '*****')
       end
     end
 
     context 'when field is boolean' do
       let(:value) { true }
 
-      it 'masks value with one asterisk' do
-        expect(processed_data).to include(field: '*')
+      it 'masks value with asterisks' do
+        expect(processed_data).to include(field: '*****')
       end
     end
 
     context 'when field is array' do
       let(:value) { [1,2,3,4] }
 
-      it 'masks value with one asterisk' do
-        expect(processed_data).to include(field: '*')
+      it 'masks value with asterisks' do
+        expect(processed_data).to include(field: '*****')
       end
     end
 
     context 'when field is hash' do
       let(:value) { {data: {}} }
 
-      it 'masks value with one asterisk' do
-        expect(processed_data).to include(field: '*')
+      it 'masks value with asterisks' do
+        expect(processed_data).to include(field: '*****')
       end
     end
 
@@ -108,7 +108,7 @@ describe Logasm::Preprocessors::Blacklist do
       let(:data) { data_with_nested_field({field: 'secret'}, depth) }
 
       it 'masks deeply nested field' do
-        expect(processed_data).to include_at_depth({field: '******'}, depth)
+        expect(processed_data).to include_at_depth({field: '*****'}, depth)
       end
     end
   end

--- a/spec/preprocessors/whitelist_spec.rb
+++ b/spec/preprocessors/whitelist_spec.rb
@@ -16,11 +16,11 @@ describe Logasm::Preprocessors::Whitelist do
 
   it 'masks all non-whitelisted fields' do
     expect(processed_data).to eq({
-      field: '******',
+      field: '*****',
       data: {
-        field: '******'
+        field: '*****'
       },
-      array: [{field: '******'}]
+      array: [{field: '*****'}]
     })
   end
 
@@ -39,9 +39,9 @@ describe Logasm::Preprocessors::Whitelist do
       expect(processed_data).to eq({
         field: 'secret',
         data: {
-          field: '******'
+          field: '*****'
         },
-        array: [{field: '******'}]
+        array: [{field: '*****'}]
       })
     end
   end
@@ -51,11 +51,11 @@ describe Logasm::Preprocessors::Whitelist do
 
     it 'includes nested field' do
       expect(processed_data).to eq({
-        field: '******',
+        field: '*****',
         data: {
           field: 'secret'
         },
-        array: [{field: '******'}]
+        array: [{field: '*****'}]
       })
     end
   end
@@ -65,9 +65,9 @@ describe Logasm::Preprocessors::Whitelist do
 
     it 'includes array element' do
       expect(processed_data).to eq({
-        field: '******',
+        field: '*****',
         data: {
-          field: '******'
+          field: '*****'
         },
         array: [{field: 'secret'}]
       })
@@ -82,7 +82,7 @@ describe Logasm::Preprocessors::Whitelist do
 
     it 'includes array elements field' do
       expect(processed_data).to include(
-        array: [{field: 'data1', secret: '*******'}, {field: 'data2', secret: '*******'}]
+        array: [{field: 'data1', secret: '*****'}, {field: 'data2', secret: '*****'}]
       )
     end
   end
@@ -102,7 +102,7 @@ describe Logasm::Preprocessors::Whitelist do
     let(:pointers) { ['/array/0'] }
 
     it 'masks array element' do
-      expect(processed_data).to include(array: [{field: '******'}])
+      expect(processed_data).to include(array: [{field: '*****'}])
     end
   end
 
@@ -110,7 +110,7 @@ describe Logasm::Preprocessors::Whitelist do
     let(:pointers) { ['/array'] }
 
     it 'masks array' do
-      expect(processed_data).to include(array: [{field: '******'}])
+      expect(processed_data).to include(array: [{field: '*****'}])
     end
   end
 
@@ -118,15 +118,15 @@ describe Logasm::Preprocessors::Whitelist do
     let(:pointers) { ['/data'] }
 
     it 'masks hash' do
-      expect(processed_data).to include(data: {field: '******'})
+      expect(processed_data).to include(data: {field: '*****'})
     end
   end
 
   context 'when boolean present' do
     let(:data) { {bool: true} }
 
-    it 'masks it with single asteriks' do
-      expect(processed_data).to eq(bool: '*')
+    it 'masks it with asteriks' do
+      expect(processed_data).to eq(bool: '*****')
     end
   end
 
@@ -173,7 +173,7 @@ describe Logasm::Preprocessors::Whitelist do
       expect(processed_data).to include('field_with_~'=> 'secret')
     end
   end
-  
+
   context 'when field has tilde and 1' do
     let(:data) {{
       'field_with_~1' => 'secret'


### PR DESCRIPTION
There are sometimes values that are very long which we want to mask.
There's no reason to display 100 askerisks if 5 is also good enough.

This should also improve security a bit because now you don't even know
the value length. Up for discussion though.