### PR TITLE
Add support for pruning out fields in Whitelist preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ You can specify the name of the field and which action to take on it.
 Nested hashes of any level are preprocessed as well.
 
 Available actions:
-    
-* exclude(`default`) - fully excludes the field and its value from the hash.
-* mask - replaces every character from the original value with `*`. In case of `array`, `hash` or `boolean` value is replaced with one `*`.
+
+* `prune` (default) - fully excludes the field and its value from the hash.
+* `mask` - replaces every character from the original value with `*`. 
+  In case of `array`, `hash` or `boolean` value is replaced with one `*`.
 
 #### Configuration
 
@@ -85,7 +86,7 @@ preprocessors:
     fields:
       - key: password
       - key: phone
-        action: mask
+    action: mask
 ```
 
 #### Usage
@@ -106,9 +107,15 @@ Received request {"info":{"phone":"************"}}
 
 ### Whitelist
 
-Masks all the fields except those whitelisted in the configuration using [JSON Pointer](https://tools.ietf.org/html/rfc6901).
+Prunes or masks all the fields except those whitelisted in the configuration using [JSON Pointer](https://tools.ietf.org/html/rfc6901).
 Only simple values(`string`, `number`, `boolean`) can be whitelisted.
 Whitelisting array and hash elements can be done using wildcard symbol `~`.
+
+Available actions:
+
+* `mask` (default) - replaces every character from the original value with `*`. 
+  In case of `array`, `hash` or `boolean` value is replaced with one `*`.
+* `prune` - fully excludes the field and its value from the hash.
 
 #### Configuration
 
@@ -116,6 +123,7 @@ Whitelisting array and hash elements can be done using wildcard symbol `~`.
 preprocessors:
   whitelist:
     pointers: ['/info/phone', '/addresses/~/host']
+  action: prune
 ```
 
 #### Usage

--- a/benchmark/whitelisting.rb
+++ b/benchmark/whitelisting.rb
@@ -10,43 +10,44 @@ pointers = %w[
   /nested_array/~/deep_array/~
 ]
 
-preprocessor = Logasm::Preprocessors::Whitelist.new(pointers: pointers)
+%w[prune mask].each do |action|
+  preprocessor = Logasm::Preprocessors::Whitelist.new(pointers: pointers, action: action)
 
+  Benchmark.ips do |x|
+    x.config(time: 5, warmup: 2)
 
-Benchmark.ips do |x|
-  x.config(time: 5, warmup: 2)
+    x.report("Scalar value whitelisting (action=#{action})") do
+      preprocessor.process(scalar: 'value', bad_scalar: 'value', hash: {})
+    end
 
-  x.report('Scalar value whitelisting') do
-    preprocessor.process(scalar: 'value', bad_scalar: 'value', hash: {})
-  end
+    x.report("Flat hash whitelisting (action=#{action})") do
+      preprocessor.process(flat_hash: { scalar: 'value', array: [1, 2], hash: {} })
+    end
 
-  x.report('Flat hash whitelisting') do
-    preprocessor.process(flat_hash: { scalar: 'value', array: [1, 2], hash: {} })
-  end
-
-  x.report('Nested hash whitelisting') do
-    preprocessor.process(
-      nested_hash: {
-        next_level_hash: {
-          deep_hash: { scalar: 'value', array: [1, 2] }
-        },
-        next_level_hash2: {
-          deep_hash: { scalar: 'value', array: [1, 2] }
-        },
-        next_level_hash3: {
-          deep_hash: { scalar: 'value', array: [1, 2] }
+    x.report("Nested hash whitelisting (action=#{action})") do
+      preprocessor.process(
+        nested_hash: {
+          next_level_hash: {
+            deep_hash: { scalar: 'value', array: [1, 2] }
+          },
+          next_level_hash2: {
+            deep_hash: { scalar: 'value', array: [1, 2] }
+          },
+          next_level_hash3: {
+            deep_hash: { scalar: 'value', array: [1, 2] }
+          }
         }
-      }
-    )
-  end
+      )
+    end
 
-  x.report('Flat array whitelisting') do
-    preprocessor.process(
-      nested_array: [
-        { deep_array: [1, 2, 3] },
-        { deep_array: [1, 2, 3] },
-        { deep_array: [1, 2, 3] }
-      ]
-    )
+    x.report("Flat array whitelisting (action=#{action})") do
+      preprocessor.process(
+        nested_array: [
+          { deep_array: [1, 2, 3] },
+          { deep_array: [1, 2, 3] },
+          { deep_array: [1, 2, 3] }
+        ]
+      )
+    end
   end
 end

--- a/lib/logasm/preprocessors/blacklist.rb
+++ b/lib/logasm/preprocessors/blacklist.rb
@@ -2,7 +2,7 @@ class Logasm
   module Preprocessors
     class Blacklist
 
-      DEFAULT_ACTION = 'exclude'
+      DEFAULT_ACTION = 'prune'
       MASK_SYMBOL = '*'
       MASKED_VALUE = MASK_SYMBOL * 5
 
@@ -52,9 +52,10 @@ class Logasm
         data.merge(key => MASKED_VALUE)
       end
 
-      def exclude_field(data, *)
+      def prune_field(data, *)
         data
       end
+      alias_method :exclude_field, :prune_field
     end
   end
 end

--- a/lib/logasm/preprocessors/strategies/mask.rb
+++ b/lib/logasm/preprocessors/strategies/mask.rb
@@ -1,0 +1,43 @@
+class Logasm
+  module Preprocessors
+    module Strategies
+      class Mask
+        MASK_SYMBOL = '*'.freeze
+        MASKED_VALUE = MASK_SYMBOL * 5
+
+        def initialize(trie)
+          @trie = trie
+        end
+
+        def process(data, pointer = '')
+          return MASKED_VALUE unless @trie.include?(pointer)
+
+          case data
+          when Hash
+            process_hash(data, pointer)
+
+          when Array
+            process_array(data, pointer)
+
+          else
+            data
+          end
+        end
+
+        private
+
+        def process_hash(data, parent_pointer)
+          data.each_with_object({}) do |(key, value), result|
+            result[key] = process(value, "#{parent_pointer}/#{key}")
+          end
+        end
+
+        def process_array(data, parent_pointer)
+          data.each_with_index.map do |value, index|
+            process(value, "#{parent_pointer}/#{index}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/logasm/preprocessors/strategies/prune.rb
+++ b/lib/logasm/preprocessors/strategies/prune.rb
@@ -1,0 +1,44 @@
+class Logasm
+  module Preprocessors
+    module Strategies
+      class Prune
+        def initialize(trie)
+          @trie = trie
+        end
+
+        def process(data, pointer = '')
+          return nil unless @trie.include?(pointer)
+
+          case data
+          when Hash
+            process_hash(data, pointer)
+
+          when Array
+            process_array(data, pointer)
+
+          else
+            data
+          end
+        end
+
+        private
+
+        def process_hash(data, parent_pointer)
+          data.each_with_object({}) do |(key, value), result|
+            path = "#{parent_pointer}/#{key}"
+
+            result[key] = process(value, path) if @trie.include?(path)
+          end
+        end
+
+        def process_array(data, parent_pointer)
+          data.each_with_index.each_with_object([]) do |(value, index), result|
+            path = "#{parent_pointer}/#{index}"
+
+            result << process(value, path) if @trie.include?(path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/logasm/preprocessors/whitelist.rb
+++ b/lib/logasm/preprocessors/whitelist.rb
@@ -1,4 +1,6 @@
 require 'logasm/preprocessors/json_pointer_trie'
+require 'logasm/preprocessors/strategies/mask'
+require 'logasm/preprocessors/strategies/prune'
 
 class Logasm
   module Preprocessors
@@ -7,21 +9,23 @@ class Logasm
       MASK_SYMBOL = '*'.freeze
       MASKED_VALUE = MASK_SYMBOL * 5
 
+      PRUNE_ACTION_NAMES = %w[prune exclude].freeze
+
       class InvalidPointerFormatException < Exception
       end
 
       def initialize(config = {})
-        pointers = (config[:pointers] || []) + DEFAULT_WHITELIST
+        trie = build_trie(config)
 
-        @trie = pointers.reduce(JSONPointerTrie.new(config)) do |trie, pointer|
-          validate_pointer(pointer)
-
-          trie.insert(decode(pointer))
-        end
+        @strategy = if PRUNE_ACTION_NAMES.include?(config[:action].to_s)
+                      Strategies::Prune.new(trie)
+                    else
+                      Strategies::Mask.new(trie)
+                    end
       end
 
       def process(data)
-        process_data('', data)
+        @strategy.process(data)
       end
 
       private
@@ -38,31 +42,13 @@ class Logasm
           .gsub('~0', '~')
       end
 
-      def process_data(parent_pointer, data)
-        return MASKED_VALUE unless @trie.include?(parent_pointer)
+      def build_trie(config)
+        pointers = (config[:pointers] || []) + DEFAULT_WHITELIST
 
-        case data
-        when Hash
-          process_hash(parent_pointer, data)
+        pointers.reduce(JSONPointerTrie.new(config)) do |trie, pointer|
+          validate_pointer(pointer)
 
-        when Array
-          process_array(parent_pointer, data)
-
-        else
-          data
-        end
-      end
-
-      def process_hash(parent_pointer, hash)
-        hash.each_with_object({}) do |(key, value), result|
-          processed = process_data("#{parent_pointer}/#{key}", value)
-          result[key] = processed
-        end
-      end
-
-      def process_array(parent_pointer, array)
-        array.each_with_index.map do |value, index|
-          process_data("#{parent_pointer}/#{index}", value)
+          trie.insert(decode(pointer))
         end
       end
     end

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "logasm"
-  gem.version       = '0.9.0'
+  gem.version       = '0.9.1'
   gem.authors       = ["Salemove"]
   gem.email         = ["support@salemove.com"]
   gem.description   = %q{It's logasmic}


### PR DESCRIPTION
Sometimes it is not feasible to just mask out fields from the output.
For example, one may want to log a big hash with only one whitelisted
field (let's say, "foo/bar"). In this case, a hash
`{foo: { bar: "value", baz: "another value" }}` would be logged as
`{foo: { bar: "value", baz: "*****" }}`. If a hash contains too many
of non-whitelisted fields, the output would become a pile of asterisks.
Also, such output is not Elasticsearch-friendly as it may bloat its
indices with useless fields.

For such cases we want to prune out non-whitelisted fields completely.

Blacklist strategy already had this option available under name "exclude".
I thought, name "prune" would be more correct and reflect intentions
better, and changed its name in code and README (without breaking
backwards-compatibility).