### PR TITLE
Increase performance of STDOUT JSON adapter

### DIFF
--- a/lib/logasm/adapters/stdout_json_adapter.rb
+++ b/lib/logasm/adapters/stdout_json_adapter.rb
@@ -1,6 +1,12 @@
 class Logasm
   module Adapters
     class StdoutJsonAdapter
+      OJ_DUMP_OPTS = {
+        mode: :compat,
+        time_format: :xmlschema,
+        second_precision: 3
+      }.freeze
+
       def initialize(level, service_name, *)
         @level = level
         @service_name = service_name
@@ -9,8 +15,8 @@ class Logasm
 
       def log(level, metadata = {})
         if meets_threshold?(level)
-          message = Utils.build_event(metadata, level, @application_name)
-          STDOUT.puts(Oj.dump(message, mode: :compat, time_format: :ruby))
+          message = Utils.build_json_event(metadata, level, @application_name)
+          STDOUT.puts(Oj.dump(message, OJ_DUMP_OPTS))
         end
       end
 

--- a/lib/logasm/utils.rb
+++ b/lib/logasm/utils.rb
@@ -2,8 +2,6 @@ require 'time'
 
 class Logasm
   module Utils
-    DECIMAL_FRACTION_OF_SECOND = 3
-
     # Build logstash json compatible event
     #
     # @param [Hash] metadata

--- a/lib/logasm/utils.rb
+++ b/lib/logasm/utils.rb
@@ -11,13 +11,12 @@ class Logasm
     # @param [String] service_name
     #
     # @return [Hash]
-    def self.build_event(metadata, level, application_name)
-      overwritable_params
-        .merge(serialize_time_objects!(metadata.dup))
-        .merge(
-          application: application_name,
-          level: level.to_s
-        )
+    def self.build_json_event(metadata, level, application_name)
+      {
+        :@timestamp => Time.now.utc,
+        application: application_name,
+        level: level
+      }.merge(metadata)
     end
 
     # Return application name
@@ -32,28 +31,6 @@ class Logasm
       underscore(service_name)
     end
 
-    def self.overwritable_params
-      {
-        :@timestamp => Time.now.utc.iso8601(DECIMAL_FRACTION_OF_SECOND)
-      }
-    end
-
-    def self.serialize_time_objects!(object)
-      if object.is_a?(Hash)
-        object.each do |key, value|
-          object[key] = serialize_time_objects!(value)
-        end
-      elsif object.is_a?(Array)
-        object.each_index do |index|
-          object[index] = serialize_time_objects!(object[index])
-        end
-      elsif object.is_a?(Time) || object.is_a?(Date)
-        object.iso8601
-      else
-        object
-      end
-    end
-
     def self.underscore(input)
       word = input.to_s.dup
       word.gsub!(/::/, '/')
@@ -63,7 +40,5 @@ class Logasm
       word.downcase!
       word
     end
-
-    private_class_method :overwritable_params
   end
 end

--- a/spec/adapters/stdout_json_adapter_spec.rb
+++ b/spec/adapters/stdout_json_adapter_spec.rb
@@ -12,12 +12,12 @@ describe Logasm::Adapters::StdoutJsonAdapter do
       let(:adapter) { described_class.new(debug_level_code, service_name) }
       let(:metadata) { {x: 'y'} }
       let(:event) { {a: 'b', x: 'y'} }
-      let(:serialized_event) { Oj.dump(event, mode: :compat, time_format: :ruby) }
+      let(:serialized_event) { Oj.dump(event, mode: :compat, time_format: :xmlschema, second_precision: 3) }
       let(:service_name) { 'my-service' }
       let(:application_name) { 'my_service' }
 
       before do
-        allow(Logasm::Utils).to receive(:build_event)
+        allow(Logasm::Utils).to receive(:build_json_event)
           .with(metadata, info_level, application_name)
           .and_return(event)
       end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 
 describe Logasm::Utils do
   describe '.build_event' do
-    subject(:event) { described_class.build_event(metadata, level, application_name) }
+    subject(:event) { described_class.build_json_event(metadata, level, application_name) }
 
     let(:application_name) { 'test_service' }
     let(:level)  { :info }
     let(:metadata) { {x: 'y'} }
+    let(:now) { Time.utc(2015, 10, 11, 23, 10, 21, 123456) }
 
     before do
-      allow(Time).to receive(:now) { Time.utc(2015, 10, 11, 23, 10, 21, 123456) }
+      allow(Time).to receive(:now) { now }
     end
 
     it 'includes it in the event as application' do
@@ -17,11 +18,11 @@ describe Logasm::Utils do
     end
 
     it 'includes log level' do
-      expect(event[:level]).to eq('info')
+      expect(event[:level]).to eq(:info)
     end
 
     it 'includes timestamp' do
-      expect(event[:@timestamp]).to eq('2015-10-11T23:10:21.123Z')
+      expect(event[:@timestamp]).to eq(now)
     end
 
     context 'when @timestamp provided' do
@@ -39,14 +40,6 @@ describe Logasm::Utils do
       it 'overwrites host' do
         expect(subject[:message]).to eq('test')
         expect(subject[:host]).to eq('xyz')
-      end
-    end
-
-    context 'when time object in metadata' do
-      let(:metadata) { {time: Time.utc(2016, 1, 5, 10, 38)} }
-
-      it 'serializes as iso8601 format' do
-        expect(subject[:time]).to eq("2016-01-05T10:38:00Z")
       end
     end
   end


### PR DESCRIPTION
1. Don't serialize timestamps in ruby, let OJ handle it
2. Don't stringify log level, let OJ convert it to string

Before:
```
$ time ruby perf.rb > /dev/null

real	0m2.550s
user	0m2.474s
sys	0m0.061s
```

After:
```
$ time ruby perf.rb > /dev/null

real	0m1.679s
user	0m1.616s
sys	0m0.052s
```

perf.rb:
```
require 'bundler/setup'
Bundler.require
logger = Logasm.build('test_service', stdout: {level: 'info', json: true})

100_000.times do
  logger.info "hello there", a: "asdf", b: 'eadsfasdf', c: {hello: 'there'}
end
```