### PR TITLE
Add JRuby compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.2
+  - 2.3
+  - 2.4
+  - jruby

--- a/lib/logasm.rb
+++ b/lib/logasm.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'oj'
 require_relative 'logasm/adapters'
 require_relative 'logasm/utils'
 require_relative 'logasm/null_logger'

--- a/lib/logasm/adapters/stdout_adapter.rb
+++ b/lib/logasm/adapters/stdout_adapter.rb
@@ -19,7 +19,7 @@ class Logasm
         data = metadata.select { |key, value| key != :message }
         log_data = [
           message,
-          data.empty? ? nil : Oj.dump(data, mode: :compat, time_format: :ruby)
+          data.empty? ? nil : Utils.generate_json(data)
         ].compact.join(' ')
 
         @logger.public_send level, log_data

--- a/lib/logasm/adapters/stdout_json_adapter.rb
+++ b/lib/logasm/adapters/stdout_json_adapter.rb
@@ -10,7 +10,7 @@ class Logasm
       def log(level, metadata = {})
         if meets_threshold?(level)
           message = Utils.build_event(metadata, level, @application_name)
-          STDOUT.puts(Oj.dump(message, mode: :compat, time_format: :ruby))
+          STDOUT.puts(Utils.generate_json(message))
         end
       end
 

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -17,7 +17,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'lru_redux'
-  gem.add_dependency 'oj'
+
+  if RUBY_PLATFORM =~ /java/
+    gem.add_dependency 'jrjackson'
+  else
+    gem.add_dependency 'oj'
+  end
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -3,7 +3,12 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
-  gem.name          = "logasm"
+  if RUBY_PLATFORM =~ /java/
+    gem.name = 'logasm-jruby'
+  else
+    gem.name = 'logasm'
+  end
+
   gem.version       = '1.1.0'
   gem.authors       = ["Salemove"]
   gem.email         = ["support@salemove.com"]

--- a/logasm.gemspec
+++ b/logasm.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
     gem.name = 'logasm'
   end
 
-  gem.version       = '1.1.0'
+  gem.version       = '1.2.0'
   gem.authors       = ["Salemove"]
   gem.email         = ["support@salemove.com"]
   gem.description   = %q{It's logasmic}

--- a/spec/adapters/stdout_json_adapter_spec.rb
+++ b/spec/adapters/stdout_json_adapter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 require_relative '../../lib/logasm/adapters/stdout_json_adapter'
 
 describe Logasm::Adapters::StdoutJsonAdapter do
@@ -12,7 +13,7 @@ describe Logasm::Adapters::StdoutJsonAdapter do
       let(:adapter) { described_class.new(debug_level_code, service_name) }
       let(:metadata) { {x: 'y'} }
       let(:event) { {a: 'b', x: 'y'} }
-      let(:serialized_event) { Oj.dump(event, mode: :compat, time_format: :ruby) }
+      let(:serialized_event) { JSON.dump(event) }
       let(:service_name) { 'my-service' }
       let(:application_name) { 'my_service' }
 


### PR DESCRIPTION
Since version 1.0.0 logasm became unusable in JRuby because
of Oj dependency (it's a C-extension and not compatible with JRuby).

This commit adds a compatibility with JRuby by using Java-specific
JSON engine JrJackson which claims to be faster than Oj on long run.

Also, for JRuby we don't have to manually convert time object into
desired format, because JrJackson supports custom time formats.